### PR TITLE
Added type hint for model_type

### DIFF
--- a/examples/extract_conceptfusion_features.py
+++ b/examples/extract_conceptfusion_features.py
@@ -41,7 +41,7 @@ class ProgramArgs:
         / "checkpoints"
         / "sam_vit_h_4b8939.pth"
     )
-    model_type = "vit_h"
+    model_type: str = "vit_h"
     # Ignore masks that have valid pixels less than this fraction (of the image area)
     bbox_area_thresh: float = 0.0005
     # Number of query points (grid size) to be sampled by SAM

--- a/examples/run_feature_fusion_and_save_map.py
+++ b/examples/run_feature_fusion_and_save_map.py
@@ -69,8 +69,6 @@ class ProgramArgs:
 
     # Directory to temporarily store embeddings to
     feat_dir: str = "saved-feat"
-    # This is a placeholder -- will be set by the script once the model is run
-    embedding_dim: int = 512  # dimensionality of embeddings
 
     # Odometry file (in format created by "realtime/compute_and_save_o3d_odom.py")
     odomfile: str = "data/azurekinect/poses.txt"


### PR DESCRIPTION
Tyro now picks up on the option so that you can specify the SAM model.

Basically the solution proposed in #9.